### PR TITLE
Fix narrow resolutions breaking background and mobile clamping issues.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ async function setup(): Promise<[Application, Viewport]> {
 		backgroundAlpha: 0,
 		antialias: false,
 		roundPixels: true,
-		autoDensity: false,
+		autoDensity: true,
 		resolution: window.devicePixelRatio,
 	});
 	document.getElementById('app')?.appendChild(app.canvas);
@@ -68,15 +68,7 @@ async function setup(): Promise<[Application, Viewport]> {
 		.decelerate()
 		.wheel()
 		.clamp({
-			left: 0,
-			right: viewport.worldWidth,
-			top: 0,
-			// Increase clamp size for mobile
-			// TODO: Still doesn't work perfectly, but "good enough"
-			bottom:
-				screen.orientation?.type.startsWith('portrait') ?
-					viewport.worldHeight * 1.15
-				:	viewport.worldHeight,
+			direction: 'all',
 			underflow: 'center',
 		})
 		.clampZoom(getClampZoom(viewport));


### PR DESCRIPTION
Two fixes:

1. Narrow resolutions on large monitors, or zooming out on narrow resolutions, would break the trick of hiding the background sprite to show the blur, because it would _always_ think the viewport was too far up. This fixes it by saying that if we are in a narrow resolution, clamp the zoom max height so it always keeps the ground in focus until the user pans up. This should have no effect on typical landscape-style use.

2. Fix mobile clamping issues; this was caused by incorrect settings when initializing the app (sorry, I changed this when trying to fix the background issues), making it so that devices like phones seemingly couldn't pan down since it would create a scroll bar that you needed to scroll first (idk why).