### PR TITLE
Add basic username search functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 				id="loading-container"
 			>
 				<div>
-					<span>Chotto matte ne</span>
+					<span id="loading-screen-text">Chotto matte ne</span>
 					<img
 						src="/loading/loading.gif"
 						class="mb-[5px] inline h-[17px] w-auto"

--- a/src/branchDatabase.ts
+++ b/src/branchDatabase.ts
@@ -1,0 +1,52 @@
+import { addRxPlugin, createRxDatabase, RxDatabase } from 'rxdb';
+import { RxDBDevModePlugin } from 'rxdb/plugins/dev-mode';
+import { getRxStorageMemory } from 'rxdb/plugins/storage-memory';
+
+export interface DonationLeafInfo {
+	username: string;
+	x: number;
+	y: number;
+	updated: string;
+}
+
+class BranchDatabase {
+	static #instance: RxDatabase;
+
+	public static get instance() {
+		return async () => {
+			if (!this.#instance) {
+				if (import.meta.env.DEV) {
+					addRxPlugin(RxDBDevModePlugin);
+				}
+
+				this.#instance = await createRxDatabase({
+					name: 'f4f-branch-db',
+					storage: getRxStorageMemory(),
+				});
+
+				if (!this.#instance.branches) {
+					await this.#instance.addCollections({
+						branches: {
+							schema: {
+								version: 0,
+								primaryKey: 'id',
+								type: 'object',
+								properties: {
+									id: { type: 'string', maxLength: 15 },
+									username: { type: 'string' },
+									x: { type: 'number' },
+									y: { type: 'number' },
+									updated: { type: 'string' },
+								},
+							},
+						},
+					});
+				}
+			}
+
+			return this.#instance;
+		};
+	}
+}
+
+export default BranchDatabase.instance;

--- a/src/branches/Branch.ts
+++ b/src/branches/Branch.ts
@@ -1,12 +1,13 @@
 import { Container, Sprite } from 'pixi.js';
 import { Donation } from '../donationPopup.ts';
 import type Leaf from './Leaf.ts';
+import { LeafCoords } from './Leaf.ts';
 
 export default abstract class Branch extends Container {
 	public readonly capacity = 15;
 
 	protected lastBranchSectionY = 0;
-	protected donations: Donation[] = [];
+	protected donationCount = 0;
 	protected leafs: Leaf[] = [];
 
 	protected constructor() {
@@ -19,18 +20,18 @@ export default abstract class Branch extends Container {
 	}
 
 	get count() {
-		return this.donations.length;
+		return this.donationCount;
 	}
 
 	get full() {
 		return this.count >= this.capacity;
 	}
 
-	addDonation(donation: Donation) {
+	addDonation(donation: Donation): LeafCoords {
 		if (this.full) throw new Error('Branch is full!');
 
-		this.donations.push(donation);
-		this.leafs[this.count - 1].setDonation(donation);
+		this.donationCount += 1;
+		return this.leafs[this.count - 1].setDonation(donation);
 	}
 
 	protected renderBranchSection(sprite: Sprite, label?: string) {

--- a/src/branches/Branch.ts
+++ b/src/branches/Branch.ts
@@ -1,7 +1,7 @@
 import { Container, Sprite } from 'pixi.js';
 import { Donation } from '../donationPopup.ts';
 import type Leaf from './Leaf.ts';
-import { LeafCoords } from './Leaf.ts';
+import { LeafInfo } from './Leaf.ts';
 
 export default abstract class Branch extends Container {
 	public readonly capacity = 15;
@@ -27,7 +27,7 @@ export default abstract class Branch extends Container {
 		return this.count >= this.capacity;
 	}
 
-	addDonation(donation: Donation): LeafCoords {
+	addDonation(donation: Donation): LeafInfo {
 		if (this.full) throw new Error('Branch is full!');
 
 		this.donationCount += 1;

--- a/src/branches/Leaf.ts
+++ b/src/branches/Leaf.ts
@@ -1,6 +1,11 @@
 import { Container, Sprite, Text } from 'pixi.js';
 import DonationPopup, { Donation } from '../donationPopup.ts';
 
+export interface LeafCoords {
+	x: number;
+	y: number;
+}
+
 export default class Leaf extends Container {
 	private readonly prerequisites?: Container[];
 	private readonly leafSprite;
@@ -59,7 +64,7 @@ export default class Leaf extends Container {
 		return [0x8eb332, undefined];
 	}
 
-	setDonation(donation: Donation) {
+	setDonation(donation: Donation): LeafCoords {
 		if (this.hasDonation) {
 			throw new Error('Cannot reassign leaf!');
 		}
@@ -86,5 +91,11 @@ export default class Leaf extends Container {
 
 		this.visible = true;
 		this.hasDonation = true;
+
+		const bounds = this.leafSprite.getBounds();
+		return {
+			x: bounds.x,
+			y: bounds.y,
+		};
 	}
 }

--- a/src/branches/Leaf.ts
+++ b/src/branches/Leaf.ts
@@ -1,9 +1,10 @@
 import { Container, Sprite, Text } from 'pixi.js';
 import DonationPopup, { Donation } from '../donationPopup.ts';
 
-export interface LeafCoords {
+export interface LeafInfo {
 	x: number;
 	y: number;
+	tint: number;
 }
 
 export default class Leaf extends Container {
@@ -64,7 +65,7 @@ export default class Leaf extends Container {
 		return [0x8eb332, undefined];
 	}
 
-	setDonation(donation: Donation): LeafCoords {
+	setDonation(donation: Donation): LeafInfo {
 		if (this.hasDonation) {
 			throw new Error('Cannot reassign leaf!');
 		}
@@ -96,6 +97,7 @@ export default class Leaf extends Container {
 		return {
 			x: bounds.x,
 			y: bounds.y,
+			tint: tint,
 		};
 	}
 }

--- a/src/components/about-modal.ts
+++ b/src/components/about-modal.ts
@@ -148,12 +148,17 @@ export class AboutModal extends LitElement {
 									>
 								</li>
 								<li>
-									Tachtician_Walt -
+									Tactician_Walt -
 									<a href="https://x.com/walt280"
 										>X / Twitter</a
 									>
 								</li>
-								<li>goose</li>
+								<li>
+									goose -
+									<a href="https://x.com/SanityUnderflow"
+										>X / Twitter</a
+									>
+								</li>
 								<li>
 									Hiro -
 									<a href="https://x.com/hiroavrs"

--- a/src/components/find-donation-modal.ts
+++ b/src/components/find-donation-modal.ts
@@ -54,26 +54,20 @@ export class FindDonationModal extends LitElement {
 				this.db = await Database();
 			}
 
+			// TODO: How should we handle anonymous donations?
 			const donations = (await this.db.donations
 				.find({
 					selector: {
 						username: { $eq: this.searchText },
 					},
+					sort: [{ updated: 'desc' }],
 				})
 				.exec()) as Donation[];
 
 			if (donations.length > 0) {
-				// Just do last donation (by update time) wins.
-				//
-				// TODO: How should we handle anonymous donations?
-				donations.sort((a, b) => {
-					// Assuming update dates are ISO 8601 dates...
-					if (a.updated < b.updated) return -1;
-					else if (a.updated > b.updated) return 1;
-					else return 0;
-				});
-
-				const lastDonation = donations[donations.length - 1];
+				// Just do last donation (by update time) wins for now.
+				const lastDonation = donations[0];
+				console.log(`${JSON.stringify(lastDonation)}`);
 			} else {
 				// TODO: Return a message saying that there was no result found.
 				this.currentError = ErrorType.NoDonationFound;
@@ -100,7 +94,7 @@ export class FindDonationModal extends LitElement {
 				<div class="separator" slot="separator"></div>
 
 				<div slot="content" class="flex flex-col gap-4">
-					<p class="text-lg">
+					<p>
 						Search for your donation by entering your sapling name!
 					</p>
 					<input
@@ -121,7 +115,7 @@ export class FindDonationModal extends LitElement {
 						}}"
 					/>
 					${errorText !== undefined ?
-						html`<p class="-mt-3 text-lg text-red-500">
+						html`<p class="-mt-3 text-red-500">
 							${errorText}
 						</p>`
 					:	html``}

--- a/src/components/find-donation-modal.ts
+++ b/src/components/find-donation-modal.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import './base-modal.ts';
 
 @customElement('find-donation-modal')
@@ -7,12 +7,39 @@ export class FindDonationModal extends LitElement {
 	@property({ type: Boolean, reflect: true })
 	isOpen = false;
 
+	@state()
+	searchText = '';
+
+	@state()
+	flashError = false;
+
 	protected createRenderRoot(): HTMLElement | DocumentFragment {
 		return this;
 	}
 
 	handleModalClosed() {
 		this.isOpen = false;
+	}
+
+	private updateText(event: InputEvent) {
+		this.flashError = false;
+
+		const target = event.target;
+
+		if (target == null) {
+			return;
+		}
+
+		this.searchText = (target as HTMLInputElement).value;
+	}
+
+	private searchName() {
+		if (this.searchText.length == 0) {
+			this.flashError = true;
+		} else {
+			this.flashError = false;
+			console.log(`Searching ${this.searchText}`);
+		}
 	}
 
 	render() {
@@ -34,9 +61,22 @@ export class FindDonationModal extends LitElement {
 						name="sapling-name"
 						placeholder="Your Sapling Name..."
 						required
-						class="text-input"
+						class="${this.flashError ? 'text-input-error' : (
+							'text-input'
+						)}"
+						@input="${(event: InputEvent) =>
+							this.updateText(event)}"
+						@keydown="${(event: KeyboardEvent) => {
+							if (event.key == 'Enter') {
+								this.searchName();
+							}
+						}}"
 					/>
-					<button id="find-donation" class="btn btn-grass">
+					<button
+						id="find-donation"
+						class="btn btn-grass"
+						@click="${() => this.searchName()}"
+					>
 						Find Donation
 					</button>
 				</div>

--- a/src/components/find-donation-modal.ts
+++ b/src/components/find-donation-modal.ts
@@ -2,8 +2,10 @@ import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import './base-modal.ts';
 import { RxDatabase } from 'rxdb';
-import BranchDatabase, { DonationLeafInfo } from '../branchDatabase.ts';
+import LeafDatabase, { LeafInfo } from '../leafDatabase.ts';
+import Database from '../database.ts';
 import { Viewport } from 'pixi-viewport';
+import DonationPopup, { Donation } from '../donationPopup.ts';
 
 enum ErrorType {
 	EmptySearch,
@@ -25,7 +27,10 @@ export class FindDonationModal extends LitElement {
 	currentError: ErrorType | null = null;
 
 	@state()
-	branchDb: RxDatabase | undefined = undefined;
+	donationDb: RxDatabase | undefined = undefined;
+
+	@state()
+	leafDb: RxDatabase | undefined = undefined;
 
 	protected createRenderRoot(): HTMLElement | DocumentFragment {
 		return this;
@@ -51,23 +56,57 @@ export class FindDonationModal extends LitElement {
 		this.searchText = (target as HTMLInputElement).value;
 	}
 
-	private snapAndZoom(x: number, y: number) {
+	private moveToLeaf(leafInfo: LeafInfo, donation: Donation) {
 		this.handleModalClosed();
 
 		if (this.viewport !== undefined) {
 			this.viewport.zoomPercent(1, true);
 
-			this.viewport.snap(x, y, {
+			this.viewport.snap(leafInfo.x, leafInfo.y, {
 				removeOnComplete: true,
 				removeOnInterrupt: true,
 			});
 
 			this.viewport.snapZoom({
-				width: 1,
+				width: 1, // Don't set this to 0 or things break horribly.
 				removeOnComplete: true,
 				removeOnInterrupt: true,
 			});
 		}
+
+		DonationPopup.setDonation(donation, leafInfo.tint);
+	}
+
+	private async findDonationsForUser() {
+		if (this.donationDb === undefined) {
+			this.donationDb = await Database();
+		}
+
+		const docs = await this.donationDb.donations
+			.find({
+				selector: {
+					// TODO: How should we handle anonymous donation usernames?
+					username: { $eq: this.searchText },
+				},
+				sort: [{ updated: 'desc' }],
+			})
+			.exec();
+
+		return docs as (Donation & { id: string })[];
+	}
+
+	private async findLeafForId(id: string) {
+		if (this.leafDb === undefined) {
+			this.leafDb = await LeafDatabase();
+		}
+
+		return (await this.leafDb.leaves
+			.findOne({
+				selector: {
+					id: { $eq: id },
+				},
+			})
+			.exec()) as LeafInfo;
 	}
 
 	private async searchName() {
@@ -76,25 +115,14 @@ export class FindDonationModal extends LitElement {
 		} else {
 			this.currentError = null;
 
-			if (this.branchDb === undefined) {
-				this.branchDb = await BranchDatabase();
-			}
-
-			// TODO: How should we handle anonymous donation usernames?
-			const donations = (await this.branchDb.branches
-				.find({
-					selector: {
-						username: { $eq: this.searchText },
-					},
-					sort: [{ updated: 'desc' }],
-				})
-				.exec()) as DonationLeafInfo[];
+			const donations = await this.findDonationsForUser();
 
 			if (donations.length > 0) {
 				// Just do last (by update time) donation wins for now.
 				const lastDonation = donations[0];
+				const leafInfo = await this.findLeafForId(lastDonation.id);
 
-				this.snapAndZoom(lastDonation.x, lastDonation.y);
+				this.moveToLeaf(leafInfo, lastDonation as Donation);
 			} else {
 				// TODO: Return a message saying that there was no result found.
 				this.currentError = ErrorType.NoDonationFound;

--- a/src/leafDatabase.ts
+++ b/src/leafDatabase.ts
@@ -2,14 +2,13 @@ import { addRxPlugin, createRxDatabase, RxDatabase } from 'rxdb';
 import { RxDBDevModePlugin } from 'rxdb/plugins/dev-mode';
 import { getRxStorageMemory } from 'rxdb/plugins/storage-memory';
 
-export interface DonationLeafInfo {
-	username: string;
+export interface LeafInfo {
 	x: number;
 	y: number;
-	updated: string;
+	tint: number;
 }
 
-class BranchDatabase {
+class LeafDatabase {
 	static #instance: RxDatabase;
 
 	public static get instance() {
@@ -26,17 +25,16 @@ class BranchDatabase {
 
 				if (!this.#instance.branches) {
 					await this.#instance.addCollections({
-						branches: {
+						leaves: {
 							schema: {
 								version: 0,
 								primaryKey: 'id',
 								type: 'object',
 								properties: {
 									id: { type: 'string', maxLength: 15 },
-									username: { type: 'string' },
 									x: { type: 'number' },
 									y: { type: 'number' },
-									updated: { type: 'string' },
+									tint: { type: 'number' },
 								},
 							},
 						},
@@ -49,4 +47,4 @@ class BranchDatabase {
 	}
 }
 
-export default BranchDatabase.instance;
+export default LeafDatabase.instance;

--- a/src/main.ts
+++ b/src/main.ts
@@ -264,7 +264,18 @@ async function setupPixi() {
 	return viewport;
 }
 
+function possibleUuuu() {
+	if (Math.floor(Math.random() * 20) >= 18) {
+		const loadingText = document.getElementById('loading-screen-text');
+		if (loadingText) {
+			(loadingText as HTMLSpanElement).textContent = 'uuuuuuuuuuuuuuuuuu';
+		}
+	}
+}
+
 void (async () => {
+	possibleUuuu();
+
 	const viewport = await setupPixi();
 
 	// Replace the #loading-container with a text that says "Click to start"

--- a/src/main.ts
+++ b/src/main.ts
@@ -260,10 +260,12 @@ async function setupPixi() {
 	setupSigns(viewport);
 	DonationPopup.init(app, viewport);
 	await setupTree(viewport);
+
+	return viewport;
 }
 
 void (async () => {
-	await setupPixi();
+	const viewport = await setupPixi();
 
 	// Replace the #loading-container with a text that says "Click to start"
 	const loadingContainer = document.getElementById('loading-container');
@@ -282,7 +284,7 @@ void (async () => {
 				void Assets.loadBundle('default').then((resources) => {
 					// Initialize background music
 					const storedVolume = localStorage.getItem('storedVolume');
-					let volume = 0.3;
+					let volume = 1;
 					if (storedVolume != null) {
 						const parsed = parseFloat(storedVolume);
 						if (!isNaN(parsed)) {
@@ -322,6 +324,16 @@ void (async () => {
 						}, 2300);
 					}
 					localStorage.setItem('hasVisited', 'true');
+				}
+
+				// Connect the viewport to the search modal.
+				const searchModal = document.querySelector(
+					'find-donation-modal',
+				) as HTMLElement & {
+					viewport: Viewport | undefined;
+				};
+				if (searchModal) {
+					searchModal.viewport = viewport;
 				}
 			});
 		}

--- a/src/style.css
+++ b/src/style.css
@@ -116,6 +116,10 @@ dialog::backdrop {
   @apply w-full rounded-md border-2 border-gray-300 p-2;
 }
 
+.text-input-error {
+  @apply w-full rounded-md border-2 border-red-400 p-2;
+}
+
 h1 {
   @apply text-3xl font-bold;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -140,6 +140,10 @@ a {
   @apply underline underline-offset-2;
 }
 
+p {
+  @apply text-lg;
+}
+
 ::-webkit-scrollbar {
   width: 4px;
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -3,7 +3,7 @@ import { Donation } from './donationPopup';
 import Branch01 from './branches/Branch01.ts';
 import Branch from './branches/Branch.ts';
 import Database from './database.ts';
-import BranchDatabase from './branchDatabase';
+import LeafDatabase from './leafDatabase.ts';
 import { RxChangeEventInsert } from 'rxdb';
 import { Viewport } from 'pixi-viewport';
 
@@ -98,7 +98,7 @@ export async function buildTreeSpriteGraph(
 	const initialDocs = (await db.donations.find().exec()) as (Donation & {
 		id: string;
 	})[];
-	const branchDB = await BranchDatabase();
+	const leafDb = await LeafDatabase();
 
 	// Build branches
 	let isLeftBranch = true;
@@ -166,14 +166,12 @@ export async function buildTreeSpriteGraph(
 			treeContainer.addChild(currentBranch);
 		}
 
-		const { x, y } = currentBranch.addDonation(donation);
-
-		void branchDB.branches.upsert({
+		const { x, y, tint } = currentBranch.addDonation(donation);
+		void leafDb.leaves.upsert({
 			id: donationId,
-			username: donation.username,
 			x: x,
 			y: y,
-			updated: donation.updated,
+			tint: tint,
 		});
 	}
 

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -3,6 +3,7 @@ import { Donation } from './donationPopup';
 import Branch01 from './branches/Branch01.ts';
 import Branch from './branches/Branch.ts';
 import Database from './database.ts';
+import BranchDatabase from './branchDatabase';
 import { RxChangeEventInsert } from 'rxdb';
 import { Viewport } from 'pixi-viewport';
 
@@ -94,8 +95,10 @@ export async function buildTreeSpriteGraph(
 	);
 
 	const db = await Database();
-
-	const donations = (await db.donations.find().exec()) as Donation[];
+	const initialDocs = (await db.donations.find().exec()) as (Donation & {
+		id: string;
+	})[];
+	const branchDB = await BranchDatabase();
 
 	// Build branches
 	let isLeftBranch = true;
@@ -115,7 +118,7 @@ export async function buildTreeSpriteGraph(
 		treeBottomX +
 		treeBase.width * (TRUNK_ACTUAL_CENTERLINE / treeBase.width - 0.5);
 
-	function addDonation(donation: Donation) {
+	function addDonation(donationId: string, donation: Donation) {
 		if (!currentBranch || currentBranch.full) {
 			currentBranch = new BRANCH_OPTIONS[
 				Math.floor(Math.random() * BRANCH_OPTIONS.length)
@@ -141,15 +144,7 @@ export async function buildTreeSpriteGraph(
 
 					viewport.plugins.remove('clamp');
 					viewport.clamp({
-						left: 0,
-						right: viewport.worldWidth,
-						top: currentClampTopLimit,
-						// Increase clamp size for mobile
-						// TODO: Still doesn't work perfectly, but "good enough"
-						bottom:
-							screen.orientation?.type.startsWith('portrait') ?
-								viewport.worldHeight * 1.15
-							:	viewport.worldHeight,
+						direction: 'all',
 						underflow: 'center',
 					});
 				}
@@ -171,15 +166,23 @@ export async function buildTreeSpriteGraph(
 			treeContainer.addChild(currentBranch);
 		}
 
-		currentBranch.addDonation(donation);
+		const { x, y } = currentBranch.addDonation(donation);
+
+		void branchDB.branches.upsert({
+			id: donationId,
+			username: donation.username,
+			x: x,
+			y: y,
+			updated: donation.updated,
+		});
 	}
 
-	for (const donation of donations) {
-		addDonation(donation);
+	for (const doc of initialDocs) {
+		addDonation(doc.id, doc as Donation);
 	}
 
 	db.donations.insert$.subscribe((event: RxChangeEventInsert<Donation>) => {
-		addDonation(event.documentData);
+		addDonation(event.documentId, event.documentData);
 	});
 
 	return treeContainer;


### PR DESCRIPTION
This PR adds the ability for a user to search for their name; when searching it will find the _most recently updated_ donation, then pan + zoom to the leaf corresponding to that, and then open the leaf as if they had clicked it.

---

Not sure if we need the opening-leaf action, but added it for now anyway. I've also only tested it on the default-generated branch.