### PR TITLE
Fix sound keeps pausing when using donation inputs

### DIFF
--- a/src/components/volume-control.ts
+++ b/src/components/volume-control.ts
@@ -1,11 +1,11 @@
-import { Sound } from '@pixi/sound';
+import { SoundLibrary } from '@pixi/sound';
 import { html, LitElement } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 
 @customElement('volume-control')
 export class VolumeControl extends LitElement {
 	@property({ type: Object })
-	backgroundMusic: Sound | null = null;
+	backgroundMusic: SoundLibrary | null = null;
 
 	@state()
 	private isMuted = false;
@@ -20,7 +20,7 @@ export class VolumeControl extends LitElement {
 		this.previousVolume = volume;
 
 		if (this.backgroundMusic) {
-			this.backgroundMusic.volume = volume;
+			this.backgroundMusic.volumeAll = volume;
 		}
 
 		localStorage.setItem('storedVolume', volume.toString());
@@ -38,7 +38,7 @@ export class VolumeControl extends LitElement {
 		if (this.isMuted) {
 			// Unmute: Restore the previous volume
 			if (this.backgroundMusic) {
-				this.backgroundMusic.volume = this.previousVolume;
+				this.backgroundMusic.volumeAll = this.previousVolume;
 			}
 			this.isMuted = false;
 			localStorage.setItem(
@@ -48,8 +48,8 @@ export class VolumeControl extends LitElement {
 		} else {
 			// Mute: Set volume to 0 and remember the previous volume
 			if (this.backgroundMusic) {
-				this.previousVolume = this.backgroundMusic.volume;
-				this.backgroundMusic.volume = 0;
+				this.previousVolume = this.backgroundMusic.volumeAll;
+				this.backgroundMusic.volumeAll = 0;
 			}
 			this.isMuted = true;
 			localStorage.setItem('storedVolume', '0');
@@ -63,12 +63,12 @@ export class VolumeControl extends LitElement {
 	render() {
 		const value =
 			this.isMuted ? 0
-			: this.backgroundMusic ? this.backgroundMusic.volume * 100
+			: this.backgroundMusic ? this.backgroundMusic.volumeAll * 100
 			: 50;
 
 		const showMuteIcon =
 			this.isMuted ||
-			(this.backgroundMusic && this.backgroundMusic.volume == 0);
+			(this.backgroundMusic && this.backgroundMusic.volumeAll == 0);
 
 		return html`
 			<div class="volume-container">
@@ -80,7 +80,7 @@ export class VolumeControl extends LitElement {
 					type="range"
 					min="0"
 					max="100"
-					.value="${value}"
+					.value="${value.toString()}"
 					@input="${(event: Event) => this.handleVolumeChange(event)}"
 				/>
 			</div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,26 +1,26 @@
 import './style.css';
 
+import { initDevtools } from '@pixi/devtools';
+import { sound, SoundLibrary } from '@pixi/sound';
+import { IClampZoomOptions, Viewport } from 'pixi-viewport';
 import {
 	Application,
 	Assets,
 	BlurFilter,
+	Bounds,
+	ColorMatrixFilter,
 	Container,
+	getGlobalBounds,
 	Graphics,
 	Rectangle,
 	Sprite,
-	TexturePool,
 	Text,
-	ColorMatrixFilter,
 	Texture,
-	getGlobalBounds,
-	Bounds,
+	TexturePool,
 } from 'pixi.js';
-import { IClampZoomOptions, Viewport } from 'pixi-viewport';
-import { initDevtools } from '@pixi/devtools';
-import { WORLD_HEIGHT, WORLD_WIDTH, CULL_MARGIN } from './PixiConfig.ts';
-import { buildTreeSpriteGraph } from './tree.ts';
 import DonationPopup from './donationPopup.ts';
-import { Sound } from '@pixi/sound';
+import { CULL_MARGIN, WORLD_HEIGHT, WORLD_WIDTH } from './PixiConfig.ts';
+import { buildTreeSpriteGraph } from './tree.ts';
 
 function getClampZoom(viewport: Viewport): IClampZoomOptions {
 	const isVertical = window.innerHeight > window.innerWidth;
@@ -304,23 +304,21 @@ void (async () => {
 					}
 
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-argument,@typescript-eslint/no-unsafe-member-access
-					const backgroundMusic = Sound.from(resources.bgm);
-					void backgroundMusic.play({
-						loop: true,
-						singleInstance: true,
-						volume: 0.3,
-					});
-					backgroundMusic.volume = volume;
+					sound.add('bgm', resources.bgm);
+					sound.disableAutoPause = true;
+					sound.volumeAll = volume;
+					// eslint-disable-next-line @typescript-eslint/no-floating-promises
+					sound.play('bgm', { loop: true });
 
 					// Connect the background music to the volume-control component
 					const volumeControl = document.querySelector(
 						'volume-control',
 					) as HTMLElement & {
-						backgroundMusic: Sound | null;
+						backgroundMusic: SoundLibrary | null;
 					};
 
 					if (volumeControl) {
-						volumeControl.backgroundMusic = backgroundMusic;
+						volumeControl.backgroundMusic = sound;
 					}
 				});
 


### PR DESCRIPTION
- This fixes an issue where if a field in the donation widget is focused, it'd pause the bgm.
- From what I read, the flag `disableAutoPause` could only be used through an instance `SoundLibrary` instead of `Sound` [pixijs/sound doc](https://pixijs.io/sound/docs/SoundLibrary.html#disableAutoPause). So I switched over to using that instead.