### PR TITLE
Use pst day as anchor for sakura day

### DIFF
--- a/src/branches/Leaf.ts
+++ b/src/branches/Leaf.ts
@@ -81,7 +81,11 @@ export default class Leaf extends Container {
 	private getTint(amount: number): [number, number] {
 		// Graduation sakura colors
 		const now = new Date();
-		if (now.getMonth() === 0 && now.getDate() === 3) {
+		const pstNow = new Date(
+			now.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' }),
+		);
+		const isSakuraDay = pstNow.getMonth() === 0 && pstNow.getDate() === 3;
+		if (isSakuraDay) {
 			const randNum = getRandomNumber(
 				0,
 				Leaf.sakuraThemeLeafColors.length,


### PR DESCRIPTION
- Sakura currently bases on local time, which wouldn't really work, since tmr is fauna's graduation but I won't be able to see the sakura leaves. So switching to anchor pst instead