### PR TITLE
Add primitive logic to keep text upright

### DIFF
--- a/src/branches/Branch.ts
+++ b/src/branches/Branch.ts
@@ -27,11 +27,11 @@ export default abstract class Branch extends Container {
 		return this.count >= this.capacity;
 	}
 
-	addDonation(donation: Donation): LeafInfo {
+	addDonation(donation: Donation, isLeftBranch: boolean): LeafInfo {
 		if (this.full) throw new Error('Branch is full!');
 
 		this.donationCount += 1;
-		return this.leafs[this.count - 1].setDonation(donation);
+		return this.leafs[this.count - 1].setDonation(donation, this.leafs[this.count - 1].angle, isLeftBranch);
 	}
 
 	protected renderBranchSection(sprite: Sprite, label?: string) {

--- a/src/branches/Branch.ts
+++ b/src/branches/Branch.ts
@@ -27,11 +27,11 @@ export default abstract class Branch extends Container {
 		return this.count >= this.capacity;
 	}
 
-	addDonation(donation: Donation, isLeftBranch: boolean): LeafInfo {
+	addDonation(donation: Donation, branchLabel: string, isLeftBranch: boolean): LeafInfo {
 		if (this.full) throw new Error('Branch is full!');
 
 		this.donationCount += 1;
-		return this.leafs[this.count - 1].setDonation(donation, this.leafs[this.count - 1].angle, isLeftBranch);
+		return this.leafs[this.count - 1].setDonation(donation, branchLabel, this.leafs[this.count - 1].label, isLeftBranch);
 	}
 
 	protected renderBranchSection(sprite: Sprite, label?: string) {

--- a/src/branches/Branch01.ts
+++ b/src/branches/Branch01.ts
@@ -5,7 +5,7 @@ import Leaf from './Leaf.ts';
 export default class Branch01 extends Branch {
 	constructor() {
 		super();
-		this.label = 'Branch variant 01';
+		this.label = 'Branch_01';
 		this.scale = 0.4;
 	}
 

--- a/src/branches/Leaf.ts
+++ b/src/branches/Leaf.ts
@@ -122,8 +122,6 @@ export default class Leaf extends Container {
 		this.usernameText.text = donation.username;
 		this.amountText.text = `$${donation.amount}`;
 
-		console.log(`name: ${this.usernameText.text} | angle: ${leafAngle} | isLeftBranch: ${isLeftBranch}`);
-
 		// Rotate text 180 degrees if it makes sense
 		const shouldRotateText = (isLeftBranch && (leafAngle < 0 || leafAngle > 170)) ||
 								(!isLeftBranch && ((leafAngle > 0 && leafAngle < 190) || leafAngle === -175));

--- a/src/branches/Leaf.ts
+++ b/src/branches/Leaf.ts
@@ -11,6 +11,11 @@ export interface LeafInfo {
 
 type BranchSide = 'leftSide' | 'rightSide';
 type BranchLabel = 'Branch_01' | 'Branch_02';
+type LeafLabel = 'Leaf 01' | 'Leaf 02' | 'Leaf 03' | 'Leaf 04' | 'Leaf 05' | 'Leaf 06' | 'Leaf 07' | 'Leaf 08' | 'Leaf 09' | 'Leaf 10' | 'Leaf 11' | 'Leaf 12' | 'Leaf 13' | 'Leaf 14' | 'Leaf 15';
+
+function isLeafLabel(label: string): label is LeafLabel {
+    return ['Leaf 01', 'Leaf 02', 'Leaf 03', 'Leaf 04', 'Leaf 05', 'Leaf 06', 'Leaf 07', 'Leaf 08', 'Leaf 09', 'Leaf 10', 'Leaf 11', 'Leaf 12', 'Leaf 13', 'Leaf 14', 'Leaf 15'].includes(label);
+}
 
 export default class Leaf extends Container {
 	private readonly prerequisites?: Container[];
@@ -20,7 +25,7 @@ export default class Leaf extends Container {
 
 	private hasDonation = false;
 
-	private static readonly leavesToRotate: Record<BranchSide, Record<BranchLabel, string[]>> = {
+	private static readonly leavesToRotate: Record<BranchSide, Record<BranchLabel, LeafLabel[]>> = {
 		'leftSide': {
 			'Branch_01': ['Leaf 01', 'Leaf 02', 'Leaf 03', 'Leaf 04', 'Leaf 05', 'Leaf 06', 'Leaf 07', 'Leaf 08', 'Leaf 09', 'Leaf 10', 'Leaf 11', 'Leaf 12', 'Leaf 14', 'Leaf 15'],
 			'Branch_02': ['Leaf 01', 'Leaf 02', 'Leaf 03', 'Leaf 04', 'Leaf 05', 'Leaf 06', 'Leaf 07', 'Leaf 08', 'Leaf 09', 'Leaf 11', 'Leaf 12', 'Leaf 13', 'Leaf 15']
@@ -139,13 +144,17 @@ export default class Leaf extends Container {
 		const currentBranch: BranchSide = isLeftBranch ? 'leftSide' : 'rightSide';
 		const currentBranchLabel: BranchLabel = branchLabel === 'Branch_01' ? 'Branch_01' : 'Branch_02'; // Oof...
 
-		const shouldRotateText = Leaf.leavesToRotate[currentBranch][currentBranchLabel].includes(leafLabel);
+		if (isLeafLabel(leafLabel)) {
+			const shouldRotateText = Leaf.leavesToRotate[currentBranch][currentBranchLabel].includes(leafLabel);
 
-		if (shouldRotateText) {
-			this.usernameText.angle += 180;
-			this.usernameText.y = 40;
-			this.amountText.angle += 180;
-			this.amountText.y = -40;
+			if (shouldRotateText) {
+				this.usernameText.angle += 180;
+				this.usernameText.y = 40;
+				this.amountText.angle += 180;
+				this.amountText.y = -40;
+			}
+		} else {
+			console.error(`Error! Invalid leaf label: ${leafLabel}\nSkipping rotation check for this leaf!`);
 		}
 
 		const [tint, brightness] = this.getTint(donation.amount);

--- a/src/branches/Leaf.ts
+++ b/src/branches/Leaf.ts
@@ -9,6 +9,9 @@ export interface LeafInfo {
 	brightness: number;
 }
 
+type BranchSide = 'leftSide' | 'rightSide';
+type BranchLabel = 'Branch_01' | 'Branch_02';
+
 export default class Leaf extends Container {
 	private readonly prerequisites?: Container[];
 	private readonly leafSprite;
@@ -16,6 +19,17 @@ export default class Leaf extends Container {
 	private readonly amountText;
 
 	private hasDonation = false;
+
+	private static readonly leavesToRotate: Record<BranchSide, Record<BranchLabel, string[]>> = {
+		'leftSide': {
+			'Branch_01': ['Leaf 01', 'Leaf 02', 'Leaf 03', 'Leaf 04', 'Leaf 05', 'Leaf 06', 'Leaf 07', 'Leaf 08', 'Leaf 09', 'Leaf 10', 'Leaf 11', 'Leaf 12', 'Leaf 14', 'Leaf 15'],
+			'Branch_02': ['Leaf 01', 'Leaf 02', 'Leaf 03', 'Leaf 04', 'Leaf 05', 'Leaf 06', 'Leaf 07', 'Leaf 08', 'Leaf 09', 'Leaf 11', 'Leaf 12', 'Leaf 13', 'Leaf 15']
+		},
+		'rightSide': {
+			'Branch_01': ['Leaf 12', 'Leaf 13'],
+			'Branch_02': ['Leaf 13', 'Leaf 14']
+		}
+	};
 
 	// tint, brightness
 	public static readonly sakuraThemeLeafColors: [number, number][] = [
@@ -111,7 +125,7 @@ export default class Leaf extends Container {
 		}
 	}
 
-	setDonation(donation: Donation, leafAngle: number, isLeftBranch: boolean): LeafInfo {
+	setDonation(donation: Donation, branchLabel: string, leafLabel: string, isLeftBranch: boolean): LeafInfo {
 		if (this.hasDonation) {
 			throw new Error('Cannot reassign leaf!');
 		}
@@ -122,21 +136,15 @@ export default class Leaf extends Container {
 		this.usernameText.text = donation.username;
 		this.amountText.text = `$${donation.amount}`;
 
-		// Rotate text 180 degrees if it makes sense
-		const shouldRotateText = (isLeftBranch && (leafAngle < 0 || leafAngle > 170)) ||
-								(!isLeftBranch && ((leafAngle > 0 && leafAngle < 190) || leafAngle === -175));
+		const currentBranch: BranchSide = isLeftBranch ? 'leftSide' : 'rightSide';
+		const currentBranchLabel: BranchLabel = branchLabel === 'Branch_01' ? 'Branch_01' : 'Branch_02'; // Oof...
+
+		const shouldRotateText = Leaf.leavesToRotate[currentBranch][currentBranchLabel].includes(leafLabel);
 
 		if (shouldRotateText) {
 			this.usernameText.angle += 180;
-			this.amountText.angle += 180;
-		}
-
-		// Swap text of leaves where donation text is now above username text
-		const shouldSwapTextPosition = (!isLeftBranch && (leafAngle === 115 || leafAngle === -175 || leafAngle === 175)) ||
-										(isLeftBranch && leafAngle !== 0 && leafAngle !== 115);
-
-		if (shouldSwapTextPosition) {
 			this.usernameText.y = 40;
+			this.amountText.angle += 180;
 			this.amountText.y = -40;
 		}
 
@@ -145,7 +153,6 @@ export default class Leaf extends Container {
 		const brightnessFilter = new ColorMatrixFilter();
 		brightnessFilter.brightness(brightness, true);
 		this.leafSprite.filters = brightnessFilter;
-
 		this.eventMode = 'static';
 		this.cursor = 'pointer';
 		this.on('pointerdown', () => {

--- a/src/branches/Leaf.ts
+++ b/src/branches/Leaf.ts
@@ -111,7 +111,7 @@ export default class Leaf extends Container {
 		}
 	}
 
-	setDonation(donation: Donation): LeafInfo {
+	setDonation(donation: Donation, leafAngle: number, isLeftBranch: boolean): LeafInfo {
 		if (this.hasDonation) {
 			throw new Error('Cannot reassign leaf!');
 		}
@@ -121,6 +121,26 @@ export default class Leaf extends Container {
 		});
 		this.usernameText.text = donation.username;
 		this.amountText.text = `$${donation.amount}`;
+
+		console.log(`name: ${this.usernameText.text} | angle: ${leafAngle} | isLeftBranch: ${isLeftBranch}`);
+
+		// Rotate text 180 degrees if it makes sense
+		const shouldRotateText = (isLeftBranch && (leafAngle < 0 || leafAngle > 170)) ||
+								(!isLeftBranch && ((leafAngle > 0 && leafAngle < 190) || leafAngle === -175));
+
+		if (shouldRotateText) {
+			this.usernameText.angle += 180;
+			this.amountText.angle += 180;
+		}
+
+		// Swap text of leaves where donation text is now above username text
+		const shouldSwapTextPosition = (!isLeftBranch && (leafAngle === 115 || leafAngle === -175 || leafAngle === 175)) ||
+										(isLeftBranch && leafAngle !== 0 && leafAngle !== 115);
+
+		if (shouldSwapTextPosition) {
+			this.usernameText.y = 40;
+			this.amountText.y = -40;
+		}
 
 		const [tint, brightness] = this.getTint(donation.amount);
 		this.leafSprite.tint = tint;

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -218,7 +218,7 @@ export async function buildTreeSpriteGraph(
 			treeContainer.addChild(currentBranch);
 		}
 
-		const { x, y, tint, brightness } = currentBranch.addDonation(donation, !isLeftBranch);
+		const { x, y, tint, brightness } = currentBranch.addDonation(donation, currentBranch.label, !isLeftBranch);
 		void db.leaves.upsert({
 			id: donationId,
 			x: x,

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -218,7 +218,7 @@ export async function buildTreeSpriteGraph(
 			treeContainer.addChild(currentBranch);
 		}
 
-		const { x, y, tint, brightness } = currentBranch.addDonation(donation);
+		const { x, y, tint, brightness } = currentBranch.addDonation(donation, !isLeftBranch);
 		void db.leaves.upsert({
 			id: donationId,
 			x: x,


### PR DESCRIPTION
This PR adds (extremely) primitive logic to ensure that the donation username and amount remain upright no matter how its leaf is rotated.

I'm sure there's 10000% a better way to do this, but my limited experience with how the site is set up made it a little tricky to comprehend the leaf rendering logic, so this bandaid fix is all I have for now. I'll gladly take a more comprehensive crack at it if this isn't sufficient!